### PR TITLE
Allow specifying some CSS grid properties as attributes on DOM nodes

### DIFF
--- a/examples/story.amp.html
+++ b/examples/story.amp.html
@@ -16,9 +16,9 @@
         <amp-img width="1192" height="2118" src="//lh3.googleusercontent.com/8odp91txMONsHazbzjr6xG6nh5eAZwkKR95VTBSik-106iQsIpQrSXOLd-TFVmwuFL0qscJeBeak-S7qhLy5TpC4hUnGfJ9vvjy0CX-Om_0glCkx_MxmhcH4WFTY_X6ACMHtm34C2KKPaF6RuxFqJQJ4-ZvCnNczNg3bv5YT5aiKSR637vqKTh8o7Sy3qD70B7iqNmsPzY0v9aAnFL60qmxQEFfOBM2kNpqN_fECiNqjEhrb6d8-d5dHxJ86Pf9FFYB3SdG6geEdKcvOOeS0Dn0R_C_FKolB8rFK0vBH7LKoVcFdFPKJJuN6bkF2nAn4ZhXZ8zHuIpeFIP0VF9H6qDqRjUJhxjYpilrD6ZLEBxV0ojuj_wCX0l-rkjhxVycNz1obk2NMl4iOBAcRwcr-IfmG1LlleRH-Bul55nvYmqWtfhQR0MZwWCH8gf0GaAmybCK-fRW7YgW1RYFwsTKHcKaC34tA_O5jUZwwuMDyz1kU_9iCPTGycu0zPxQv4YWH4OyuW0InOhMCscsZ6ObcRZAz3rPrhBX51yyoqtaa9q3hIXZFI6M8cZMzx06jW1LP0Uf9u5K1tpBQcK2tvz6sjDa7zGvq6GWe5tms4CVBOxQhgZ8VKzjFxawXHYQP3hgMcdkSCfNgai-1p5AEUYhBZ0XnS0tyk_svCtAtTu5s4Q=w1192-h2118-no">
         </amp-img>
       </amp-story-grid-layer>
-      <amp-story-grid-layer template="thirds">
-        <h1 grid-area="middle-third">Jon has cute cats</h1>
-        <p grid-area="lower-third">This is a story with absolutely no thought put into storytelling; just cute cats!</p>
+      <amp-story-grid-layer template="vertical">
+        <h1>Jon has cute cats</h1>
+        <p>This is a story with absolutely no thought put into storytelling; just cute cats!</p>
       </amp-story-grid-layer>
     </amp-story-page>
     <amp-story-page id="mia">


### PR DESCRIPTION
This will allow convenience attributes, where publishers can specify the following CSS properties as HTML attributes:

- align-content
- align-items
- align-self
- grid-area
- justify-content
- justify-items
- justify-self