### PR TITLE
Fix thirds template

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -164,7 +164,7 @@ amp-story-grid-layer[template="horizontal"] {
 }
 
 amp-story-grid-layer[template="thirds"] {
-  grid-template-rows: repeat(3, auto) !important;
+  grid-template-rows: repeat(3, 1fr) !important;
   grid-template-areas: "upper-third"
                        "middle-third"
                        "lower-third" !important;


### PR DESCRIPTION
This should properly split the layer into three evenly-sized rows; `auto` sizes according to the content.