### PR TITLE
Always render text with geometric precision.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -24,6 +24,7 @@ amp-story, amp-story-page, amp-story-grid-layer {
 amp-story {
   height: 100% !important;
   position: relative !important;
+  text-rendering: geometricPrecision !important;
   width: 100% !important;
 }
 


### PR DESCRIPTION
In some cases, this can make a drastic difference in how the text appears.

Before:
![screenshot](https://user-images.githubusercontent.com/1651960/27595588-f03679fa-5b11-11e7-88cc-b69ed398d0e5.png)

After:
![screenshot](https://user-images.githubusercontent.com/1651960/27595589-f03d0450-5b11-11e7-8c44-88a42c576739.png)

The latter is the intended effect.  For a very visual framework like this one, I think it's worth it.  The footnotes from the [MDN docs on text-rendering](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering) all list side effects that have been resolved for several browser versions.  Anecdotally; trying it out in a prototype seems to work on all tested devices.