### PR TITLE
Fix issues caused by sync from amphtml repo

### DIFF
--- a/examples/stamp/7_planets/index.html
+++ b/examples/stamp/7_planets/index.html
@@ -2,13 +2,13 @@
 <html ⚡ 📖>
 <head>
   <meta charset="utf-8">
-  <script async src="https://stamp-prototype.appspot.com/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-story"
-      src="https://stamp-prototype.appspot.com/v0/amp-story-0.1.js"></script>
+      src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
   <script async custom-element="amp-video"
-      src="https://stamp-prototype.appspot.com/v0/amp-video-0.1.js"></script>
+      src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async custom-element="amp-google-vrview-image"
-      src="https://stamp-prototype.appspot.com/v0/amp-google-vrview-image-0.1.js">
+      src="https://cdn.ampproject.org/v0/amp-google-vrview-image-0.1.js">
   </script>
   <script async custom-element="amp-viewer-integration"
       src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js">

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -35,7 +35,7 @@ import {NavigationState} from './navigation-state';
 import {SystemLayer} from './system-layer';
 import {Layout} from '../../../src/layout';
 import {VariableService} from './variable-service';
-import {actionServiceForDoc} from '../../../src/services';
+import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
 import {buildFromJson} from './related-articles';
 import {closest} from '../../../src/dom';
@@ -50,8 +50,6 @@ import {
   toggleExperiment,
 } from '../../../src/experiments';
 import {registerServiceBuilder} from '../../../src/service';
-import {urlReplacementsForDoc} from '../../../src/services';
-import {xhrFor} from '../../../src/services';
 import {isFiniteNumber} from '../../../src/types';
 import {AudioManager} from './audio';
 
@@ -332,7 +330,7 @@ export class AmpStory extends AMP.BaseElement {
   triggerActiveEventForPage_() {
     // TODO(alanorozco): pass event priority once STAMP repo is merged with
     // upstream.
-    actionServiceForDoc(this.element)
+    Services.actionServiceForDoc(this.element)
         .trigger(this.activePage_, 'active', /* event */ null);
   }
 
@@ -535,9 +533,9 @@ export class AmpStory extends AMP.BaseElement {
       return Promise.resolve(null);
     }
 
-    return urlReplacementsForDoc(this.getAmpDoc())
+    return Services.urlReplacementsForDoc(this.getAmpDoc())
         .expandAsync(user().assertString(rawUrl))
-        .then(url => xhrFor(this.win).fetchJson(url))
+        .then(url => Services.xhrFor(this.win).fetchJson(url))
         .then(response => {
           user().assert(response.ok, 'Invalid HTTP response');
           return response.json();

--- a/extensions/amp-story/0.1/audio.js
+++ b/extensions/amp-story/0.1/audio.js
@@ -1,5 +1,5 @@
 import {dev} from '../../../src/log';
-import {xhrFor} from '../../../src/services';
+import {Services} from '../../../src/services';
 
 /**
  * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
@@ -280,7 +280,7 @@ class BackgroundPlayable extends Playable {
       return Promise.resolve();
     }
 
-    return xhrFor(window)
+    return Services.xhrFor(window)
         .fetch(this.sourceUri_)
         .then(response => response.arrayBuffer())
         .then(arrayBuffer => this.decodeAudioData_(arrayBuffer))

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -16,7 +16,7 @@
 import {EventType, dispatch} from './events';
 import {dev} from '../../../src/log';
 import {scale, setStyles} from '../../../src/style';
-import {vsyncFor} from '../../../src/services';
+import {Services} from '../../../src/services';
 
 
 // TODO(alanorozco): Use a precompiled template for performance
@@ -128,7 +128,7 @@ export class SystemLayer {
    * @private
    */
   getVsync_() {
-    return vsyncFor(this.win_);
+    return Services.vsyncFor(this.win_);
   }
 
   /**

--- a/src/services.js
+++ b/src/services.js
@@ -230,6 +230,15 @@ export class Services {
   }
 
   /**
+   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @return {!./service/resources-impl.Resources}
+   */
+  static resourcesForDoc(nodeOrDoc) {
+    return /** @type {!./service/resources-impl.Resources} */ (
+        getServiceForDoc(nodeOrDoc, 'resources'));
+  }
+
+  /**
    * @param {!Window} win
    * @return {?Promise<?{incomingFragment: string, outgoingFragment: string}>}
    */
@@ -238,17 +247,6 @@ export class Services {
       !Promise<?{incomingFragment: string, outgoingFragment: string}>} */ (
       getElementServiceIfAvailable(win, 'share-tracking', 'amp-share-tracking',
           true)));
-  }
-
-
-  /**
-   * @param {!Window} win
-   * @return {?Promise<?{pageIndex: number, pageId: string}>}
-   */
-  static storyVariableServiceForOrNull(win) {
-    return (/** @type {!Promise<?{pageIndex: number, pageId: string}>} */ (
-        getElementServiceIfAvailable(win, 'story-variable', 'amp-story',
-            true)));
   }
 
   /**


### PR DESCRIPTION
- Examples should always use `cdn.ampproject.org` URL instead of `stamp-prototype.appspot.com`
- Services should now import the `Services` class instead of the specific function(s) to be used
- Remove duplicate `storyVariableServiceForOrNull` function