### PR TITLE
Rename 'auto-advance-delay' attribute to 'auto-advance-after'

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -385,28 +385,28 @@ export class AmpStory extends AMP.BaseElement {
 
 
   /**
-   * If the auto-advance-delay property is set, a timer is set for that
+   * If the auto-advance-after property is set, a timer is set for that
    * duration, after which next_() will be invoked.
    * @private
    */
   maybeScheduleAutoAdvance_() {
     const activePage = dev().assert(this.activePage_,
         'No active page set when scheduling auto-advance.');
-    const autoAdvanceDelay = activePage.getAttribute('auto-advance-delay');
+    const autoAdvanceAfter = activePage.getAttribute('auto-advance-after');
 
-    if (!autoAdvanceDelay) {
+    if (!autoAdvanceAfter) {
       return;
     }
 
     let delayMs;
-    if (TIME_REGEX.MILLISECONDS.test(autoAdvanceDelay)) {
-      delayMs = Number(TIME_REGEX.MILLISECONDS.exec(autoAdvanceDelay)[1]);
-    } else if (TIME_REGEX.SECONDS.test(autoAdvanceDelay)) {
-      delayMs = Number(TIME_REGEX.SECONDS.exec(autoAdvanceDelay)[1]) * 1000;
+    if (TIME_REGEX.MILLISECONDS.test(autoAdvanceAfter)) {
+      delayMs = Number(TIME_REGEX.MILLISECONDS.exec(autoAdvanceAfter)[1]);
+    } else if (TIME_REGEX.SECONDS.test(autoAdvanceAfter)) {
+      delayMs = Number(TIME_REGEX.SECONDS.exec(autoAdvanceAfter)[1]) * 1000;
     }
 
     user().assert(isFiniteNumber(delayMs) && delayMs > 0,
-        `Invalid automatic advance delay '${autoAdvanceDelay}' ` +
+        `Invalid automatic advance delay '${autoAdvanceAfter}' ` +
         `for page '${activePage.id}'.`);
 
     this.win.setTimeout(


### PR DESCRIPTION
Rename the `auto-advance-delay` attribute to `auto-advance-after`, as this attribute will eventually also allow specifying an ID of a media element (audio/video) whose completion should trigger advancement to the next page.