### PR TITLE
Hide the amp video equalizer in STAMP

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -146,6 +146,10 @@ amp-story.unmuted .i-amp-story-mute-audio-control {
   display: block;
 }
 
+amp-story .amp-video-eq {
+  display: none !important;
+}
+
 /** Page level */
 amp-story-page {
   bottom: 0 !important;


### PR DESCRIPTION
This icon shows up to indicate that audio is playing in the video, which we have a separate indicator for in STAMP.

Fixes #110 