### PR TITLE
Set up a URL endpoint to proxy stories, changing the host for the extension/runtime to point at the current server

### DIFF
--- a/stamp-prototype/app.js
+++ b/stamp-prototype/app.js
@@ -1,10 +1,60 @@
 'use strict';
 
 var express = require('express');
+var fetch = require('node-fetch');
 var https = require('express-force-https');
 
 var app = express();
 var ORIGIN_REGEX = /^https?:\/\/[^\/]+/;
+
+var CONTENT_TYPE_HEADER_NAME = 'content-type';
+var STAMP_PROTOTYPE_HOST = /https?\:\/\/stamp-prototype.appspot.com/gi;
+
+var sendResponse = function(res, statusCode, body) {
+  res.status(statusCode).send(body);
+};
+
+app.get('/test/*', function(req, res) {
+  var url = req.params[0];
+  if (!url) {
+    sendResponse(res, 400, 'Must specify document URL.');
+    return;
+  }
+
+  fetch(url)
+      .then(function(fetchResponse) {
+        var contentType = fetchResponse.headers.get(CONTENT_TYPE_HEADER_NAME);
+        res.setHeader(CONTENT_TYPE_HEADER_NAME, contentType);
+
+        if (!contentType.indexOf('text/html') === 0) {
+          // For content types that we don't handle, just directly proxy the
+          // resource without doing anything additional.
+          fetchResponse.body.pipe(res);
+          return;
+        }
+
+        fetchResponse.text().then(function(incomingHtml) {
+          console.log(req);
+          var currentHost = 'https://' + req.headers.host;
+          var baseUrl = url.substring(0, url.lastIndexOf('/')) + '/';
+          var outgoingHtml = incomingHtml;
+          outgoingHtml = outgoingHtml
+              // Add a base href to avoid proxying dependencies.
+              .replace(/<html(.*?)>/, '<html$1><base href="' + baseUrl + '">')
+
+              // Replace the stamp-prototype base URL with the current base URL.
+              .replace(STAMP_PROTOTYPE_HOST, currentHost);
+
+          // Send the response.
+          sendResponse(res, 200, outgoingHtml);
+          return;
+        }).catch(function(error) {
+          sendResponse(res, 500, error);
+        });
+      }).catch(function(error) {
+        sendResponse(res, 500, error);
+      });
+});
 
 app.use(function(req, res, next) {
   if (req.headers.referer) {

--- a/stamp-prototype/package.json
+++ b/stamp-prototype/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "express": "4.14.1",
-    "express-force-https": "1.0.0"
+    "express-force-https": "1.0.0",
+    "node-fetch": "1.6.3"
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
This will allow us to preview content on staging builds without pushing the builds to prod.