### PR TITLE
Stopgap to fix build until core animations code can be refactored

### DIFF
--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -32,13 +32,13 @@ let WebAnimationRunner;
 let WebAnimationBuilder;
 
 
-
 /**
  * TODO(#161): Merge this with
  * !../../amp-animation/0.1/web-animation-types.WebKeyframesDef.
  * @typedef {!Object<string, *>|!Array<!Object<string, *>>}
  */
 let WebKeyframesDef;
+
 
 /**
  * TODO(#161) Merge this with


### PR DESCRIPTION
This pulls the necessary animations constants and typedefs into the `amp-story` extension, and types the full classes (`WebAnimationRunner` and `WebAnimationBuilder`) as `*` (any type) for the time being.

This is a workaround for #161, but ideally we will do what that issue describes and move the constants, classes, and typedefs into a location accessible by both the `amp-animation` and `amp-story` extensions.