### PR TITLE
Allow poster images to make page be shown

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -51,6 +51,13 @@ const PAGE_LOADED_CLASS_NAME = 'i-amp-story-page-loaded';
 
 
 /**
+ * CSS class for an amp-story-page that indicates the entire page can be shown.
+ * @const {string}
+ */
+const PAGE_SHOWN_CLASS_NAME = 'i-amp-story-page-shown';
+
+
+/**
  * The duration of time (in milliseconds) to show the loading screen for this
  * page, before showing the page content.
  * @const {number}
@@ -192,8 +199,15 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @private */
   markPageAsLoaded_() {
+    this.isLoaded_ = true;
     this.element.classList.add(PAGE_LOADED_CLASS_NAME);
     this.resolveLoadPromise_();
+  }
+
+
+  /** @private */
+  markPageAsShown_() {
+    this.element.classList.add(PAGE_SHOWN_CLASS_NAME);
   }
 
 
@@ -224,21 +238,30 @@ export class AmpStoryPage extends AMP.BaseElement {
       return true;
     }
 
-    const isLoaded = this.pageElements_.reduce(
-        (otherPageElementsAreLoaded, pageElement) => {
-          pageElement.updateState();
-          const currentPageElementIsLoaded =
-              (pageElement.isLoaded || pageElement.hasFailed);
-          return otherPageElementsAreLoaded && currentPageElementIsLoaded;
-        }, /* initialValue */ true);
+    let isPageLoaded = true;
+    let canPageBeShown = false;
 
-    this.isLoaded_ = isLoaded;
+    this.pageElements_.forEach(pageElement => {
+      pageElement.updateState();
 
-    if (this.isLoaded_) {
+      if (isPageLoaded) {
+        isPageLoaded = pageElement.isLoaded || pageElement.hasFailed;
+      }
+
+      if (!canPageBeShown) {
+        canPageBeShown = pageElement.canBeShown;
+      }
+    });
+
+    if (isPageLoaded) {
       this.markPageAsLoaded_();
     }
 
-    return this.isLoaded_;
+    if (canPageBeShown) {
+      this.markPageAsShown_();
+    }
+
+    return isPageLoaded;
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -244,8 +244,9 @@ amp-story-page[active] .i-amp-story-page-loading-screen {
   font-size: 14px;
 }
 
-amp-story-page.i-amp-story-page-loaded > .i-amp-story-page-loading-screen {
+amp-story-page.i-amp-story-page-shown > .i-amp-story-page-loading-screen {
   opacity: 0;
+  pointer-events: none;
 }
 
 /** Grid level */

--- a/extensions/amp-story/0.1/page-element.js
+++ b/extensions/amp-story/0.1/page-element.js
@@ -114,12 +114,6 @@ export class PageElement {
    * @public
    */
   updateState() {
-    if (!this.canBeShown) {
-      this.canBeShown = this.canBeShown_();
-      this.element.classList
-          .toggle(ELEMENT_SHOW_CLASS_NAME, /* force */ this.canBeShown);
-    }
-
     if (!this.isLoaded && !this.hasFailed) {
       this.isLoaded = this.isLoaded_();
       this.element.classList
@@ -130,6 +124,12 @@ export class PageElement {
       this.hasFailed = this.hasFailed_();
       this.element.classList
           .toggle(ELEMENT_FAILED_CLASS_NAME, /* force */ this.hasFailed);
+    }
+
+    if (!this.canBeShown) {
+      this.canBeShown = this.canBeShown_() || this.isLoaded;
+      this.element.classList
+          .toggle(ELEMENT_SHOW_CLASS_NAME, /* force */ this.canBeShown);
     }
   }
 
@@ -200,7 +200,11 @@ class MediaElement extends PageElement {
   /** @override */
   canBeShown_() {
     const mediaElement = this.getMediaElement_();
-    return Boolean(mediaElement && mediaElement.readyState >= 2);
+    if (!mediaElement) {
+      return false;
+    }
+
+    return mediaElement.readyState >= 2 || mediaElement.hasAttribute('poster');
   }
 
   /** @override */


### PR DESCRIPTION
This makes pages be shown as soon as the poster image has been loaded, rather than waiting for the video to be loaded as well.  Playback of video, audio, and animations will still wait for the video to be loaded (or until it times out).