### PR TITLE
Change bookend to support top-level config, social share

### DIFF
--- a/examples/story-bookend-config.json
+++ b/examples/story-bookend-config.json
@@ -1,0 +1,38 @@
+{
+  "share-providers": {
+    "facebook": true,
+    "twitter": true,
+    "gplus": true,
+    "email": true,
+    "tumblr": true
+  },
+  "related-articles": {
+    "More to Read": [
+      {
+        "title": "This is India and the best places you should go",
+        "url": "http://a-publisher.com/india",
+        "image": "http://placekitten.com/g/200/200"
+      },
+      {
+        "title": "A wonderful weekend with Tenturi",
+        "url": "http://a-publisher.com/india",
+        "image": "http://placekitten.com/g/220/220"
+      },
+      {
+        "title": "Go to Istanbul, the historical city where east meets west",
+        "url": "http://a-publisher.com/istanbul",
+        "image": "http://placekitten.com/g/240/240"
+      }
+    ],
+    "": [
+      {
+        "title": "Examining the moon",
+        "url": "http://a-publisher.com/the-moon"
+      },
+      {
+        "title": "Architecture in the thousand-year capital",
+        "url": "http://a-publisher.com/architecture"
+      }
+    ]
+  }
+}

--- a/examples/story.amp.html
+++ b/examples/story.amp.html
@@ -11,7 +11,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-story related-articles="story-related.json">
+  <amp-story bookend-config-src="story-bookend-config.json">
     <amp-story-page id="cover">
       <amp-story-grid-layer template="fill">
         <amp-img width="1192" height="2118" src="//lh3.googleusercontent.com/8odp91txMONsHazbzjr6xG6nh5eAZwkKR95VTBSik-106iQsIpQrSXOLd-TFVmwuFL0qscJeBeak-S7qhLy5TpC4hUnGfJ9vvjy0CX-Om_0glCkx_MxmhcH4WFTY_X6ACMHtm34C2KKPaF6RuxFqJQJ4-ZvCnNczNg3bv5YT5aiKSR637vqKTh8o7Sy3qD70B7iqNmsPzY0v9aAnFL60qmxQEFfOBM2kNpqN_fECiNqjEhrb6d8-d5dHxJ86Pf9FFYB3SdG6geEdKcvOOeS0Dn0R_C_FKolB8rFK0vBH7LKoVcFdFPKJJuN6bkF2nAn4ZhXZ8zHuIpeFIP0VF9H6qDqRjUJhxjYpilrD6ZLEBxV0ojuj_wCX0l-rkjhxVycNz1obk2NMl4iOBAcRwcr-IfmG1LlleRH-Bul55nvYmqWtfhQR0MZwWCH8gf0GaAmybCK-fRW7YgW1RYFwsTKHcKaC34tA_O5jUZwwuMDyz1kU_9iCPTGycu0zPxQv4YWH4OyuW0InOhMCscsZ6ObcRZAz3rPrhBX51yyoqtaa9q3hIXZFI6M8cZMzx06jW1LP0Uf9u5K1tpBQcK2tvz6sjDa7zGvq6GWe5tms4CVBOxQhgZ8VKzjFxawXHYQP3hgMcdkSCfNgai-1p5AEUYhBZ0XnS0tyk_svCtAtTu5s4Q=w1192-h2118-no">

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -395,22 +395,19 @@ amp-story-grid-layer * {
   fill: #fff;
 }
 
-.i-amp-story-share-carousel {
+.i-amp-story-share-list {
+  display: flex;
+  list-style: none;
+  flex-wrap: nowrap;
+  padding: 16px 0;
   /* negative margin = outer padding for container for horizontal scrolling */
-  margin: 0 -32px !important;
+  margin: 0 -32px;
+  overflow: auto;
 }
 
-.i-amp-story-share-carousel >
-    .i-amphtml-scrollable-carousel-container::-webkit-scrollbar {
+.i-amp-story-share-list::-webkit-scrollbar {
   width: 0px;
   background: transparent;
-}
-
-.i-amp-story-share-list {
-  list-style: none;
-  flex-wrap: wrap;
-  padding: 16px 32px;
-  margin: 0;
 }
 
 .i-amp-story-share-icon {
@@ -441,11 +438,11 @@ amp-social-share.i-amp-story-share-icon[type=email] {
 }
 
 .i-amp-story-share-list > li:first-child {
-  padding-left: 0;
+  padding-left: 32px;
 }
 
 .i-amp-story-share-list > li:last-child {
-  padding-right: 0;
+  padding-right: 32px;
 }
 
 .i-amp-story-share-name {

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -341,7 +341,7 @@ amp-story-grid-layer * {
   text-transform: uppercase;
   font-size: 10px;
   padding: 0 0 8px;
-  margin: 16px 0 8px;
+  margin: 48px 0 8px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.25);
   color: rgba(255, 255, 255, 0.54);
   font-family: 'Roboto', sans-serif;
@@ -391,39 +391,70 @@ amp-story-grid-layer * {
   border-top: 1px solid rgba(255, 255, 255, 0.25);
 }
 
-.i-amp-story-bookend-share-icon > svg {
+.i-amp-story-share-icon > svg {
   fill: #fff;
 }
 
-.i-amp-story-bookend-share {
-  margin: 0;
-  padding: 0;
+.i-amp-story-share-carousel {
+  /* negative margin = outer padding for container for horizontal scrolling */
+  margin: 0 -32px !important;
+}
+
+.i-amp-story-share-carousel >
+    .i-amphtml-scrollable-carousel-container::-webkit-scrollbar {
+  width: 0px;
+  background: transparent;
+}
+
+.i-amp-story-share-list {
   list-style: none;
-  display: flex;
   flex-wrap: wrap;
+  padding: 16px 32px;
+  margin: 0;
 }
 
-.i-amp-story-bookend-share-icon {
+.i-amp-story-share-icon {
   box-sizing: border-box;
-
-  /* setting to 44px with padding and negative margin to meet touch target
-  size criteria in material design */
-  padding: 6px;
-  margin: -6px;
-  width: 44px;
-  height: 44px;
+  width: 48px;
+  height: 48px;
+  padding: 8px;
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  background-size: 32px 32px;
+  display: block !important;
 }
 
-.i-amp-story-bookend-share > li {
-  margin: 16px 0;
-  display: flex;
-  flex-basis: 33.333%;
+.i-amp-story-share-icon:active {
+  background-color: rgba(255, 255, 255, 0.6);
+  outline: none;
 }
 
-.i-amp-story-bookend-share > li:nth-child(3n + 2) {
-  justify-content: center;
+amp-social-share.i-amp-story-share-icon[type=email] {
+  background-image: none !important;
 }
 
-.i-amp-story-bookend-share > li:nth-child(3n + 3) {
-  justify-content: flex-end;
+.i-amp-story-share-list > li {
+  width: 48px;
+  height: 66px;
+  padding: 0 16px;
+  display: inline-block;
+}
+
+.i-amp-story-share-list > li:first-child {
+  padding-left: 0;
+}
+
+.i-amp-story-share-list > li:last-child {
+  padding-right: 0;
+}
+
+.i-amp-story-share-name {
+  display: block;
+  text-align: center;
+  text-transform: capitalize;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 400;
+  line-height: 10px;
+  font-size: 10px;
+  padding: 8px 0 0;
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -69,6 +69,9 @@ const ACTIVE_PAGE_ATTRIBUTE_NAME = 'active';
 const RELATED_ARTICLES_ATTRIBUTE_NAME = 'related-articles';
 
 /** @private @const {string} */
+const BOOKEND_CONFIG_ATTRIBUTE_NAME = 'bookend-config-src';
+
+/** @private @const {string} */
 const AMP_STORY_STANDALONE_ATTRIBUTE = 'standalone';
 
 const TIME_REGEX = {
@@ -130,12 +133,8 @@ export class AmpStory extends AMP.BaseElement {
     /** @const @private {!AudioManager} */
     this.audioManager_ = new AudioManager(this.win, this.element);
 
-    /**
-     * @private @const {
-     *   !function():!Promise<?Array<!./related-articles.RelatedArticleSet>
-     * }
-     */
-    this.loadRelatedArticles_ = once(() => this.loadRelatedArticlesImpl_());
+    /** @private @const {!function():!Promise<?./bookend.BookendConfig>} */
+    this.loadBookendConfig_ = once(() => this.loadBookendConfigImpl_());
 
     /** @private {?Element} */
     this.activePage_ = null;
@@ -844,25 +843,65 @@ export class AmpStory extends AMP.BaseElement {
 
     this.element.appendChild(this.bookend_.build());
 
-    this.loadRelatedArticles_().then(articleSets => {
-      if (articleSets === null) {
-        return;
+    this.setAsOwner(this.bookend_.getRoot());
+
+    this.loadBookendConfig_().then(bookendConfig => {
+      if (bookendConfig !== null) {
+        this.bookend_.setConfig(dev().assert(bookendConfig));
       }
-      this.bookend_.setRelatedArticles(dev().assert(articleSets));
+      this.scheduleResume(this.bookend_.getRoot());
     });
   }
 
 
   /**
-   * @return {!Promise<?Array<!./related-articles.RelatedArticleSet>>}
+   * @return {!Promise<?./bookend.BookendConfig>}
    * @private
    */
-  loadRelatedArticlesImpl_() {
-    const rawUrl = this.getRelatedArticlesUrlOptional_();
+  loadBookendConfigImpl_() {
+    // two-tiered implementation for backwards-compatibility with
+    // related-articles attribute
+    return this.loadBookendConfigInternal_().then(bookendConfig =>
+        bookendConfig || this.loadRelatedArticlesAsBookendConfig_());
+  }
 
-    if (rawUrl === null) {
+
+  /**
+   * @return {!Promise<?./bookend.BookendConfig>}
+   */
+  loadBookendConfigInternal_() {
+    return this.loadJsonFromAttribute_(BOOKEND_CONFIG_ATTRIBUTE_NAME)
+        .then(response => response && {
+          shareProviders: response['share-providers'],
+          relatedArticles: response['related-articles'] ?
+              buildFromJson(response['related-articles']) : [],
+        });
+  }
+
+
+  /**
+   * @return {!Promise<?./bookend.BookendConfig>}
+   * @private
+   */
+  loadRelatedArticlesAsBookendConfig_() {
+    return this.loadJsonFromAttribute_(RELATED_ARTICLES_ATTRIBUTE_NAME)
+        .then(response => response && {
+          relatedArticles: buildFromJson(response),
+        });
+  }
+
+
+  /**
+   * @param {string} attributeName
+   * @return {!Promise<?JsonObject>}
+   * @private
+   */
+  loadJsonFromAttribute_(attributeName) {
+    if (!this.element.hasAttribute(attributeName)) {
       return Promise.resolve(null);
     }
+
+    const rawUrl = this.element.getAttribute(attributeName);
 
     return Services.urlReplacementsForDoc(this.getAmpDoc())
         .expandAsync(user().assertString(rawUrl))
@@ -870,20 +909,7 @@ export class AmpStory extends AMP.BaseElement {
         .then(response => {
           user().assert(response.ok, 'Invalid HTTP response');
           return response.json();
-        })
-        .then(buildFromJson);
-  }
-
-
-  /**
-   * @return {?string}
-   * @private
-   */
-  getRelatedArticlesUrlOptional_() {
-    if (!this.element.hasAttribute(RELATED_ARTICLES_ATTRIBUTE_NAME)) {
-      return null;
-    }
-    return this.element.getAttribute(RELATED_ARTICLES_ATTRIBUTE_NAME);
+        });
   }
 
   /**

--- a/extensions/amp-story/0.1/bookend-share.js
+++ b/extensions/amp-story/0.1/bookend-share.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ICONS} from './icons';
+import {Services} from '../../../src/services';
+import {isObject} from '../../../src/types';
+import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
+import {dev, user} from '../../../src/log';
+import {dict} from './../../../src/utils/object';
+
+
+const LINK_SHARE_TEMPLATE =
+    `<div class="i-amp-story-share-icon">
+      ${ICONS.link}
+    </div>
+    <span class="i-amp-story-share-name">Get link</span>`;
+
+
+/**
+ * Maps share provider type to visible name.
+ * If the name only needs to be capitalized (e.g. `facebook` to `Facebook`) it
+ * does not need to be included here.
+ * @const {!JsonObject}
+ */
+const SHARE_PROVIDER_NAME = dict({
+  'gplus': 'Google+',
+  'linkedin': 'LinkedIn',
+  'whatsapp': 'WhatsApp',
+});
+
+
+/**
+ * @param {string} type
+ * @param {!JsonObject=} opt_params
+ * @return {string}
+ */
+// TODO(alanorozco): article metadata
+function shareProviderHtml(type, opt_params) {
+  const params = !opt_params ? '' :
+      Object.keys(opt_params)
+          .map(field =>
+              `data-param-${escapeHtml(field)}=` +
+              `"${escapeHtml(opt_params[field])}"`)
+          .join(' ');
+
+  const name = SHARE_PROVIDER_NAME[type] || type;
+
+  // `email` should have an icon different than the default in amp-social-share,
+  // so it is special-cased
+  const icon = type == 'email' ? ICONS.mail : '';
+
+  return (
+      `<amp-social-share
+          type="${type}"
+          width="48"
+          height="48"
+          class="i-amp-story-share-icon"
+          ${params}>
+          ${icon}
+      </amp-social-share>
+      <span class="i-amp-story-share-name">${name}</span>`
+  );
+}
+
+
+export class BookendShareWidget {
+  /** @param {!Window} win */
+  constructor(win) {
+    /** @private {!Window} */
+    this.win_ = win;
+
+    /** @private {?Element} */
+    this.root_ = null;
+  }
+
+  /** @param {!Window} win */
+  static create(win) {
+    return new BookendShareWidget(win);
+  }
+
+  /** @return {!Element} */
+  build() {
+    dev().assert(!this.root_, 'Already built.');
+
+    this.root_ = createElementWithAttributes(this.win_.document, 'ul', {
+      'class': 'i-amp-story-share-list',
+    });
+
+    this.add_(this.buildItem_(LINK_SHARE_TEMPLATE));
+
+    this.maybeAddNativeShare_();
+
+    return this.root_;
+  }
+
+  /** @private */
+  maybeAddNativeShare_() {
+    // TODO(alanorozco): Implement
+  }
+
+  /**
+   * @param {!Array<!JsonObject>} providers
+   * @public
+   */
+  // TODO(alanorozco): Set story metadata in share config
+  setProviders(providers) {
+    const fragment = this.win_.document.createDocumentFragment();
+
+    this.loadRequiredExtensions_();
+
+    Object.keys(providers).forEach(type => {
+      if (isObject(providers[type])) {
+        fragment.appendChild(
+            this.buildProvider_(type,
+                /** @type {!JsonObject} */ (providers[type])));
+        return;
+      }
+
+      // Bookend config API requires real boolean, not just truthy
+      if (providers[type] === true) {
+        fragment.appendChild(this.buildProvider_(type));
+        return;
+      }
+
+      user().warn(
+          'Invalid amp-story bookend share configuration for %s. ' +
+          'Value must be `true` or a params object.',
+          type);
+    });
+
+    this.add_(fragment);
+  }
+
+  /** @private */
+  loadRequiredExtensions_() {
+    Services.extensionsFor(this.win_).loadExtension('amp-social-share');
+  }
+
+  /**
+   * @param {string} type
+   * @param {!JsonObject=} opt_params
+   * @return {!Element}
+   * @private
+   */
+  buildProvider_(type, opt_params) {
+    return this.buildItem_(shareProviderHtml(type, opt_params));
+  }
+
+  /**
+   * @param {string} html
+   * @return {!Element}
+   * @private
+   */
+  buildItem_(html) {
+    const el = this.win_.document.createElement('li');
+    el./*OK*/innerHTML = html;
+    return el;
+  }
+
+  /**
+   * @param {!Node} node
+   * @private
+   */
+  add_(node) {
+    dev().assert(this.root_).appendChild(node);
+  }
+}

--- a/extensions/amp-story/0.1/bookend.js
+++ b/extensions/amp-story/0.1/bookend.js
@@ -15,22 +15,52 @@
  */
 import {ICONS} from './icons';
 import {EventType, dispatch} from './events';
+import {Services} from '../../../src/services';
 import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
-import {dev} from '../../../src/log';
+import {dev, user} from '../../../src/log';
+import {dict} from './../../../src/utils/object';
+import {isObject} from '../../../src/types';
 import {scale, setStyles} from '../../../src/style';
 import {vsyncFor} from '../../../src/services';
 
 
+/**
+ * @typedef {{
+ *   shareProviders: !JsonObject|undefined,
+ *   relatedArticles: !Array<!./related-articles.RelatedArticleSet>
+ * }}
+ */
+export let BookendConfig;
+
+
+/**
+ * Maps share provider type to visible name.
+ * If the name only needs to be capitalized (e.g. `facebook` to `Facebook`) it
+ * does not need to be included here.
+ * @const {!JsonObject}
+ */
+const SHARE_PROVIDER_NAME = dict({
+  'gplus': 'Google+',
+  'linkedin': 'LinkedIn',
+  'whatsapp': 'WhatsApp',
+});
+
+
 // TODO(alanorozco): Use a precompiled template for performance
 const TEMPLATE =
-    `<h3 class="i-amp-story-bookend-heading">Share the story</h3>
-    <ul class="i-amp-story-bookend-share">
-      <li>
-        <div class="i-amp-story-bookend-share-icon">
-          ${ICONS.link}
-        </div>
-      </li>
-    </ul>`;
+    `<amp-carousel class="i-amp-story-share-carousel"
+        height="98"
+        layout="fixed-height"
+        type="carousel">
+      <ul class="i-amp-story-share-list">
+        <li>
+          <div class="i-amp-story-share-icon">
+            ${ICONS.link}
+          </div>
+          <span class="i-amp-story-share-name">Get link</span>
+        </li>
+      </ul>
+    </amp-carousel>`;
 
 
 /**
@@ -59,6 +89,38 @@ function articleHtml(articleData) {
       <div class="i-amp-story-bookend-article-meta">
         example.com - 10 mins
       </div>`
+  );
+}
+
+
+/**
+ * @param {string} type
+ * @param {!JsonObject=} opt_params
+ * @return {string}
+ */
+// TODO(alanorozco): article metadata
+function shareProviderHtml(type, opt_params) {
+  const params = !opt_params ? '' :
+      Object.keys(opt_params)
+          .map(field => `data-param-${field}="${opt_params[field]}"`)
+          .join(' ');
+
+  const name = SHARE_PROVIDER_NAME[type] || type;
+
+  // `email` should have an icon different than the default in amp-social-share,
+  // so it is special-cased
+  const icon = type == 'email' ? ICONS.mail : '';
+
+  return (
+      `<amp-social-share
+          type="${type}"
+          width="48"
+          height="48"
+          class="i-amp-story-share-icon"
+          ${params}>
+          ${icon}
+      </amp-social-share>
+      <span class="i-amp-story-share-name">${name}</span>`
   );
 }
 
@@ -95,7 +157,14 @@ export class Bookend {
     this.root_.classList.add('i-amp-story-bookend');
     this.root_./*OK*/innerHTML = TEMPLATE;
 
+    this.loadRequiredExtensions_();
+
     return this.getRoot();
+  }
+
+  /** @private */
+  loadRequiredExtensions_() {
+    Services.extensionsFor(this.win_).loadExtension('amp-carousel');
   }
 
   /**
@@ -111,11 +180,92 @@ export class Bookend {
   }
 
   /**
-   * @param {!Array<!./related-articles.RelatedArticleSet>} articleSets
+   * @param {!BookendConfig} bookendConfig
    */
-  setRelatedArticles(articleSets) {
+  setConfig(bookendConfig) {
     this.assertBuilt_();
 
+    if (bookendConfig.shareProviders) {
+      Services.extensionsFor(this.win_).loadExtension('amp-social-share');
+      this.setShareProviders_(dev().assert(bookendConfig.shareProviders));
+    }
+
+    this.maybeInsertNativeShare_();
+
+    this.setRelatedArticles_(bookendConfig.relatedArticles);
+  }
+
+  /** @private */
+  maybeInsertNativeShare_() {
+    // TODO(alanorozco): Implement
+  }
+
+  /**
+   * @param {!Array<!JsonObject>} shareProviders
+   * @private
+   */
+  // TODO(alanorozco): Set story metadata in share config
+  setShareProviders_(shareProviders) {
+    const fragment = this.win_.document.createDocumentFragment();
+
+    Object.keys(shareProviders).forEach(type => {
+      if (isObject(shareProviders[type])) {
+        fragment.appendChild(
+            this.buildShareProvider_(type,
+                /** @type {!JsonObject} */ (shareProviders[type])));
+        return;
+      }
+
+      // Bookend config API requires real boolean, not just truthy
+      if (shareProviders[type] === true) {
+        fragment.appendChild(this.buildShareProvider_(type));
+        return;
+      }
+
+      user().warn(
+          'Invalid amp-story bookend share configuration for %s. ' +
+          'Value must be `true` or a params object.',
+          type);
+    });
+
+    this.insertShareItem_(fragment);
+  }
+
+  /**
+   * @param {string} type
+   * @param {!JsonObject=} opt_params
+   * @return {!Element}
+   * @private
+   */
+  buildShareProvider_(type, opt_params) {
+    return this.buildShareItem_(shareProviderHtml(type, opt_params));
+  }
+
+  /**
+   * @param {string} html
+   * @return {!Element}
+   * @private
+   */
+  buildShareItem_(html) {
+    const el = this.win_.document.createElement('li');
+    el./*OK*/innerHTML = html;
+    return el;
+  }
+
+  /**
+   * @param {!Node} node
+   * @private
+   */
+  insertShareItem_(node) {
+    dev().assert(this.getRoot().querySelector('.i-amp-story-share-list'))
+        .appendChild(node);
+  }
+
+  /**
+   * @param {!Array<!./related-articles.RelatedArticleSet>} articleSets
+   * @private
+   */
+  setRelatedArticles_(articleSets) {
     const fragment = this.win_.document.createDocumentFragment();
 
     articleSets.forEach(articleSet =>

--- a/extensions/amp-story/0.1/icons.js
+++ b/extensions/amp-story/0.1/icons.js
@@ -15,13 +15,6 @@
  */
 
 export const ICONS = {
-  googleplus:
-      `<svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" viewBox="0 0 24 24">
-        <path fill="none" d="M0 0h24v24H0V0z"/>
-        <path d="M23 11h-2V9h-2v2h-2v2h2v2h2v-2h2zM8 11v2.4h3.97c-.16 1.03-1.2 3.02-3.97 3.02-2.39 0-4.34-1.98-4.34-4.42S5.61 7.58 8 7.58c1.36 0 2.27.58 2.79 1.08l1.9-1.83C11.47 5.69 9.89 5 8 5c-3.87 0-7 3.13-7 7s3.13 7 7 7c4.04 0 6.72-2.84 6.72-6.84 0-.46-.05-.81-.11-1.16H8z"/>
-        <path fill="none" d="M1 5h14v14H1z"/>
-      </svg>`,
-
   mail:
       `<svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" viewBox="0 0 24 24">
         <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>


### PR DESCRIPTION
### Orthogonal

- Updated style to match new redlines.

### TODO

- Get link.
- Pass article metadata to social share icons.

### Bonus

- `amp-story` now owns the resource for the bookend element and applies layout/resume. This means that the bookend can now contain AMP elements.
    - using `amp-carousel` and `amp-social-share`
    - follow-up PR to use `amp-img` instead of `img`.